### PR TITLE
Use VU.State's Dialer

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -190,6 +190,7 @@ func (mi *sse) open(ctx context.Context, state *lib.State,
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{
+			DialContext:     state.Dialer.DialContext,
 			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsConfig,
 		},


### PR DESCRIPTION
Use the VU.State's Dialer to respect the IPs and hostnames block lists defined by k6 options.