### PR TITLE
fix: request http is not cancelled on Close

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ See the [K6 SSE Extension design](docs/design/021-sse-api.md).
 
 ## k6 version
 
-This extension is tested with `k6` version `v0.55.0` last release is [v0.1.5](https://github.com/phymbert/xk6-sse/releases/tag/v0.1.5).
+This extension is tested with `k6` version `v0.55.0` last release is [v0.1.6](https://github.com/phymbert/xk6-sse/releases/tag/v0.1.6).
 
 ## Build
 


### PR DESCRIPTION
Fix #23

Fix  client. Close() is triggering to many tcp connections