### PR TITLE
Allow to disable HTTP keep alives

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ See the [K6 SSE Extension design](docs/design/021-sse-api.md).
 
 ## k6 version
 
-This extension is tested with `k6` version `v0.55.0` last release is [v0.1.6](https://github.com/phymbert/xk6-sse/releases/tag/v0.1.6).
+This extension is tested with `k6` version `v0.55.0` last release is [v0.1.7](https://github.com/phymbert/xk6-sse/releases/tag/v0.1.7).
 
 ## Build
 

--- a/sse.go
+++ b/sse.go
@@ -197,6 +197,8 @@ func (mi *sse) open(ctx context.Context, state *lib.State, rt *sobek.Runtime,
 			DialContext:     state.Dialer.DialContext,
 			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsConfig,
+			// FIXME phymbert: it would be more interesting to allow reusing the transport across iterations
+			DisableKeepAlives: state.Options.NoConnectionReuse.ValueOrZero() || state.Options.NoVUConnectionReuse.ValueOrZero(),
 		},
 	}
 


### PR DESCRIPTION
Disable HTTP keep alives if --no-connection-reuse or --no-vu-connection-reuse are set.

Fix #23